### PR TITLE
Proposed fix for issue #2 Install fails

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,4 +7,5 @@ homepage: https://github.com/jeffmoss/toastd
 
 dependencies:	
   browser: any
+  unittest: any
   rikulo: '>=0.6.0 <2.0.0'


### PR DESCRIPTION
I get this error from pub get:
Pub: Get Dependencies: Package toastd depends on unittest from unknown source "sdk".

After changing pubspec to this:
  toastd: #">=1.0.0 <2.0.0"
    git: https://github.com/darkoverlordofdata/toastd

Pub: Get Dependencies: Got dependencies successfully.
